### PR TITLE
fix: Improve provider reliability and add entity-based routing

### DIFF
--- a/provider/kafka/kafka.go
+++ b/provider/kafka/kafka.go
@@ -223,7 +223,11 @@ func (p *Provider) Subscribe(ctx context.Context, topic string, handler provider
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
-		defer cg.Close() // Close this topic's consumer group when done
+		defer func() {
+			if err := cg.Close(); err != nil {
+				log.Printf("Kafka Provider: Failed to close consumer group for topic %s: %v", topic, err)
+			}
+		}()
 		for {
 			if err := cg.Consume(subCtx, []string{topic}, consumerHandler); err != nil {
 				log.Printf("Kafka Provider: Error from consumer for topic %s: %v", topic, err)


### PR DESCRIPTION
This commit addresses multiple issues with Kafka and RabbitMQ providers and adds entity type filtering to routing rules.

## Kafka Provider Fixes

### Fixed: Consumer group blocking on multiple subscriptions
- Issue: Using a shared consumer group caused Subscribe() calls to block, preventing additional topic subscriptions
- Solution: Each Subscribe() call now creates a dedicated consumer group with format "{base_group}-{topic}"
- Impact: Multiple topic subscriptions now work correctly without blocking

## RabbitMQ Provider Fixes

### Fixed: Channel closure on passive queue declare
- Issue: RabbitMQ closes channels when QueueDeclarePassive() is called on non-existent queues, causing subsequent operations to fail with "channel/connection is not open" errors
- Solution: Added reopenChannel() method that creates new channel, re-declares exchange, and resets QoS
- Impact: TopicExists() and ExchangeExists() no longer break the provider

### Added: Direct queue consumption support
- Issue: Workers publish directly to queues, but Subscribe() was creating new auto-generated queues and binding to exchanges
- Solution: Added use_topic_as_queue config option to consume from existing queues without creating bindings
- Impact: Can now consume from pre-existing queues set up by workers

## Routing Engine Improvements

### Added: Automatic entity type filtering for routing rules
- Issue: Rules defined under "dinosaur" entity were matching "habitat" entities and vice versa, causing cross-contamination
- Solution: Rules are automatically wrapped with entity type checks: `has(event.entity_type) && event.entity_type == "{type}" && (condition)`
- Impact: Rules now properly scope to their declared entity type

## Files Changed
- provider/kafka/kafka.go: Per-topic consumer groups
- provider/rabbitmq/rabbitmq.go: Direct queue consumption option
- provider/rabbitmq/topicmanager.go: Channel recovery mechanism
- routing/config.go: Entity type filtering

Tested with both Kafka and RabbitMQ providers in production workload.